### PR TITLE
✨feat: adiciona box de resposta do modal

### DIFF
--- a/auxia/src/App.vue
+++ b/auxia/src/App.vue
@@ -1,6 +1,5 @@
-<script setup>
+<script setup lang="ts">
 import { RouterLink, RouterView } from 'vue-router'
-
 
 </script>
 
@@ -9,6 +8,5 @@ import { RouterLink, RouterView } from 'vue-router'
 </template>
 
 <style scoped>
-
 
 </style>

--- a/auxia/src/components/BoxRespostaModal.vue
+++ b/auxia/src/components/BoxRespostaModal.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="container">
+    <p class="text">
+      {{props.resposta}}
+    </p>
+
+  </div>
+</template>
+
+
+<script setup lang="ts">
+const props = defineProps<{resposta: string}>();
+
+</script>
+
+<style scoped>
+.container{
+  width: 36.5rem;
+  height: 40rem;
+  background-color: #D9D9D9;
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+.text{
+  font-size: 1.25rem;
+  font-family: sans-serif;
+}
+</style>


### PR DESCRIPTION
# Mudanças
Adiciona o componente que será futuramente adicionado ao modal de avaliação da resposta para mostrar a resposta dentro do modal 

# Task no Jira
A6S-57-Criar-box-de-exibir-conteúdo-dentro-do-modal

# Commits no pr
[✨feat: adiciona box de resposta do modal](https://github.com/BuzzTech-API/auxia-frontend/commit/c2dc2dfb2e3a9f223bf650aceff1897128ef9432)


# Visualização do componente e sua contraparte do figma
![Imagem do componente](https://github.com/user-attachments/assets/8d70aac6-1f0d-430b-a161-d9505ec220d2)
Há padding no final do texto, como excedeu o tamanho ele está habilitado para ter o scroll, só não está sendo exibido ali
![Imagem do figma](https://github.com/user-attachments/assets/21ca126a-6dbe-4eec-baaa-a05bcc4f35e3)
